### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To help you with this, `doxygen` is utilized by default by the build system to
 create an HTML API documentation.  
 Further more the overviews in this README show which header to include for what.
 
-### Feeding you compiler/linker
+### Feeding your compiler/linker
 To get the correct compiler and linker flags, you can utilize pkg-config. The
 package is called pwxlib.  
 For the correct compiler flags, use


### PR DESCRIPTION
Also, what is the default precision of SCT? First it says [`-1`](https://github.com/Yamakuzure/pwxlib/blob/748eccb3af9794d9c848a808651d0bc7088a0896/README.md#pwxsct---the-sine-cosine-table), later [`3`](https://github.com/Yamakuzure/pwxlib/blob/748eccb3af9794d9c848a808651d0bc7088a0896/README.md#setprecision). Maybe I just didn't read that part right... :thinking: 